### PR TITLE
Defer autorequire

### DIFF
--- a/templates/js.tpl
+++ b/templates/js.tpl
@@ -5,5 +5,7 @@ require.register("<%= filePath %>", function(exports, require, module){
   <% } %>
 });
 <% if (autoRequire) { %>
-require("<%= filePath %>");
+setTimeout(function() {
+  require("<%= filePath %>");
+}, 1);
 <% } %>


### PR DESCRIPTION
When auto requiring we should wait for all modules to register. We dont know modules order
