### PR TITLE
Allow relative path names

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ gulp.task('commonjs', function(){
 });
 ```
 
+#### options.relativePath
+Type: `String`
+Default: `false`
+
+Allows you to set a base directory, which will allow modules to use relative
+paths.
+
+Example:
+
+```javascript
+var commonjsWrap = require('gulp-wrap-commonjs');
+
+gulp.task('commonjs', function(){
+  gulp.src(['lib/*.js'])
+    .pipe(commonjsWrap({
+      relativePath: 'lib'
+    }))
+    .pipe(gulp.dest('build/'));
+});
+
+```
+
+produces modules that look like:
+
+```js
+require.register("module.js", function(exports, require, module){
+```
+
+instead of
+
+```js
+require.register("/path/to/project/lib/module.js", function(exports, require, module){
+```
+
 #### options.pathModifier
 Type: `Function`
 Default: `false`

--- a/index.coffee
+++ b/index.coffee
@@ -3,12 +3,14 @@
 PLUGIN_NAME = 'gulp-wrap-commonjs'
 
 fs      = require 'fs'
+path    = require 'path'
 _       = require 'lodash'
 through = require 'through2'
 
 defaultOptions =
   autoRequire: false
   moduleExports: false
+  relativePath: false
   pathModifier: false
   coffee: false
 
@@ -28,7 +30,9 @@ module.exports = (options = {}) ->
       filePath = file.path
       if typeof options.pathModifier is "function"
         filePath = options.pathModifier file.path
-        
+      if typeof options.relativePath is "string"
+        filePath = path.relative(path.join(process.cwd(), options.relativePath), filePath)
+
       params =
         contents: file.contents.toString 'utf8'
         filePath: filePath


### PR DESCRIPTION
Allows you to set a base directory, which will allow modules to use relative
paths.

Example:

```javascript
var commonjsWrap = require('gulp-wrap-commonjs');

gulp.task('commonjs', function(){
  gulp.src(['lib/*.js'])
    .pipe(commonjsWrap({
      relativePath: 'lib'
    }))
    .pipe(gulp.dest('build/'));
});

```

produces modules that look like:

```js
require.register("module.js", function(exports, require, module){
```

instead of

```js
require.register("/path/to/project/lib/module.js", function(exports, require, module){
```
